### PR TITLE
Create iApp manifest and export button

### DIFF
--- a/app/builder/iapps/confidential-playground/run/[id]/results/page.tsx
+++ b/app/builder/iapps/confidential-playground/run/[id]/results/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useParams } from "next/navigation";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import AppShell from "@/components/AppShell";
 import { ProofBadge } from "@/components/ProofBadge";
@@ -11,6 +11,8 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { useStore } from "@/lib/store";
 import { getGatewayUrl } from "@/lib/storage";
 import { decryptFile, type EncryptionMeta } from "@/lib/crypto";
+import { makeIAppManifest } from "@/lib/iapp";
+import type { Job, RunConfig } from "@/lib/jobs/types";
 
 type StoredMeta = {
   iv: string;
@@ -28,6 +30,8 @@ export default function ResultsPage() {
   const [plainName, setPlainName] = useState<string | undefined>(undefined);
   const [jsonPreview, setJsonPreview] = useState<unknown | null>(null);
   const [busy, setBusy] = useState<"download" | "decrypt" | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+  const toastTimerRef = useRef<number | null>(null);
 
   const storedMetaKey = useMemo(() => (id ? `run-meta:${id}` : undefined), [id]);
 
@@ -95,6 +99,49 @@ export default function ResultsPage() {
     }
   }, [encBlob, loadStoredMeta]);
 
+  const showToast = useCallback((msg: string) => {
+    setToast(msg);
+    if (toastTimerRef.current) {
+      window.clearTimeout(toastTimerRef.current);
+    }
+    toastTimerRef.current = window.setTimeout(() => {
+      setToast(null);
+      toastTimerRef.current = null;
+    }, 2400);
+  }, []);
+
+  const handleExportIApp = useCallback(() => {
+    if (!run) return;
+
+    const job: Job = {
+      id: run.id,
+      status: run.status as any,
+      createdAt: new Date(run.createdAt).toISOString(),
+      proofHash: run.proofHash,
+      resultCid: run.resultCid
+    };
+
+    const runConfig: RunConfig = {
+      scenario: run.scenario,
+      model: run.model,
+      resourceClass: "gpu-small",
+      datasetCid: "TODO",
+      estRlc: run.estimate.rlc,
+      estMins: run.estimate.minutes
+    };
+
+    const manifest = makeIAppManifest(runConfig, job);
+    const blob = new Blob([JSON.stringify(manifest, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "manifest.json";
+    a.click();
+    URL.revokeObjectURL(url);
+
+    showToast("TODO: POST to Builder endpoint when available");
+  }, [run, showToast]);
+
   function renderJsonTable(value: unknown) {
     if (!value || typeof value !== "object") return null;
     const obj = value as Record<string, unknown>;
@@ -145,6 +192,9 @@ export default function ResultsPage() {
             }}
           >
             Copy link
+          </Button>
+          <Button variant="primary" onClick={handleExportIApp}>
+            Export as iApp
           </Button>
         </div>
       </div>
@@ -218,6 +268,11 @@ export default function ResultsPage() {
           </Card>
         </TabsContent>
       </Tabs>
+      {toast && (
+        <div className="fixed bottom-4 right-4 bg-elev border border-border rounded-md shadow px-3 py-2 text-sm">
+          {toast}
+        </div>
+      )}
     </AppShell>
   );
 }

--- a/app/builder/iapps/confidential-playground/run/[id]/results/page.tsx
+++ b/app/builder/iapps/confidential-playground/run/[id]/results/page.tsx
@@ -13,6 +13,7 @@ import { getGatewayUrl } from "@/lib/storage";
 import { decryptFile, type EncryptionMeta } from "@/lib/crypto";
 import { makeIAppManifest } from "@/lib/iapp";
 import type { Job, RunConfig } from "@/lib/jobs/types";
+import { getDeployUrl } from "@/lib/builder";
 
 type StoredMeta = {
   iv: string;
@@ -142,6 +143,31 @@ export default function ResultsPage() {
     showToast("TODO: POST to Builder endpoint when available");
   }, [run, showToast]);
 
+  const handleDeployInBuilder = useCallback(() => {
+    if (!run) return;
+
+    const job: Job = {
+      id: run.id,
+      status: run.status as any,
+      createdAt: new Date(run.createdAt).toISOString(),
+      proofHash: run.proofHash,
+      resultCid: run.resultCid
+    };
+
+    const runConfig: RunConfig = {
+      scenario: run.scenario,
+      model: run.model,
+      resourceClass: "gpu-small",
+      datasetCid: "TODO",
+      estRlc: run.estimate.rlc,
+      estMins: run.estimate.minutes
+    };
+
+    const manifest = makeIAppManifest(runConfig, job);
+    const href = getDeployUrl(manifest);
+    window.open(href, "_blank", "noopener,noreferrer");
+  }, [run]);
+
   function renderJsonTable(value: unknown) {
     if (!value || typeof value !== "object") return null;
     const obj = value as Record<string, unknown>;
@@ -195,6 +221,9 @@ export default function ResultsPage() {
           </Button>
           <Button variant="primary" onClick={handleExportIApp}>
             Export as iApp
+          </Button>
+          <Button variant="secondary" onClick={handleDeployInBuilder}>
+            Deploy in Builder
           </Button>
         </div>
       </div>

--- a/lib/builder.ts
+++ b/lib/builder.ts
@@ -1,0 +1,60 @@
+/**
+ * Build a deep link URL to deploy an iApp manifest in Builder.
+ * For now, generates a data: URL with an HTML page that displays the manifest
+ * and includes a stub POST form.
+ */
+export function getDeployUrl(manifest: unknown): string {
+  const json = JSON.stringify(manifest, null, 2);
+
+  function escapeHtml(input: string): string {
+    return input
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  const html = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Builder Deploy Stub</title>
+  <style>
+    body { font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, Apple Color Emoji, Segoe UI Emoji; padding: 16px; }
+    pre { background: #0b0b0c; color: #eaeaea; padding: 12px; border-radius: 8px; overflow: auto; }
+    .row { margin: 16px 0; }
+    button { background: #6e5df6; color: white; border: 0; padding: 8px 12px; border-radius: 8px; cursor: pointer; }
+    button:hover { opacity: .9; }
+    .muted { color: #9aa0a6; font-size: 12px; }
+  </style>
+  <script>
+    function postStub(e){
+      e.preventDefault();
+      alert('TODO: POST to Builder endpoint when available');
+    }
+    function copyJson(){
+      navigator.clipboard.writeText(document.getElementById('json').textContent);
+    }
+  </script>
+  </head>
+  <body>
+    <h1>Builder Deploy Stub</h1>
+    <div class="row muted">This page was opened via a data: URL. Replace the form action when the Builder endpoint is ready.</div>
+    <div class="row">
+      <pre id="json">${escapeHtml(json)}</pre>
+    </div>
+    <div class="row">
+      <form method="post" action="#" onsubmit="postStub(event)">
+        <input type="hidden" name="manifest" value='${escapeHtml(json)}' />
+        <button type="submit">POST to Builder (stub)</button>
+        <button type="button" style="margin-left:8px;background:#2d2e33" onclick="copyJson()">Copy JSON</button>
+      </form>
+    </div>
+  </body>
+  </html>`;
+
+  return `data:text/html;charset=utf-8,${encodeURIComponent(html)}`;
+}
+

--- a/lib/iapp.ts
+++ b/lib/iapp.ts
@@ -1,0 +1,37 @@
+import type { RunConfig, Job } from "./jobs/types";
+
+/**
+ * Build an iApp manifest JSON for Builder deploy flow.
+ * Currently returns placeholder keys; shape may evolve with Builder API.
+ */
+export function makeIAppManifest(runConfig: RunConfig, job: Job) {
+  const manifest = {
+    version: 1,
+    name: "confidential-playground-export",
+    description: "Placeholder iApp export generated from a confidential run",
+    source: {
+      scenario: runConfig.scenario,
+      model: runConfig.model,
+      resourceClass: runConfig.resourceClass,
+      datasetCid: runConfig.datasetCid
+    },
+    execution: {
+      jobId: job.id,
+      createdAt: job.createdAt,
+      status: job.status,
+      proofHash: job.proofHash ?? null,
+      resultCid: job.resultCid ?? null
+    },
+    // Placeholder keys for future Builder deploy integration
+    builder: {
+      appId: "TODO",
+      endpoint: "TODO",
+      params: {
+        // add concrete params when Builder endpoint is available
+      }
+    }
+  } as const;
+
+  return manifest;
+}
+


### PR DESCRIPTION
Add "Export as iApp" button to Results page to download a manifest.json, supporting Builder's deploy flow.

---
<a href="https://cursor.com/background-agent?bcId=bc-dc28ea14-29e5-4890-bc9e-26959092887c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dc28ea14-29e5-4890-bc9e-26959092887c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

